### PR TITLE
Simplify isolateDomain API

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ SuperGenPass password generation engine.
 ```javascript
 var supergenpass = require('supergenpass');
 
-// Generate a password.
-supergenpass('master-password', 'domain.example.com', {
+// Generate a password from a master password and a URL or a domain.
+supergenpass('master-password', 'http://domain.example.com/', {
 
     // Disable subdomain removal
     disableTLD: false,
@@ -27,9 +27,11 @@ supergenpass('master-password', 'domain.example.com', {
 
 });
 
-// Isolate a hostname using SGP's rules.
-var disableTLD = true;
-supergenpass.isolateHostname('domain.example.com', disableTLD);
+// Isolate a hostname from a URL using SGP's rules.
+supergenpass.hostname('http://domain.example.com/', {
+    // Disable subdomain removal
+    disableTLD: false
+});
 ```
 
 To use supergenpass library in browser environments, run `gulp browserify`.

--- a/supergenpass.js
+++ b/supergenpass.js
@@ -145,13 +145,20 @@ var api = function (masterPassword, domain, options) {
 
 // Public API method: isolateHostname
 // ----------------------------------
-// supergenpass.isolateHostname(uri, disableTLD)
+// supergenpass.hostname(uri, {...})
 
 // Processes a URI to isolate the domain name or IP address. By default, it
 // attempts to remove subdomains for the TLDs it knows about (set `disableTLD`
 // to true to disable this behavior).
 
-api.isolateHostname = gp2_process_uri;
+api.hostname = function (url, options) {
+
+	// Load options.
+	options = options || {};
+	options.disableTLD = options.disableTLD || false;
+
+	return gp2_process_uri(url, options.disableTLD);
+};
 
 
 // Export public API.

--- a/tests/hostnames.js
+++ b/tests/hostnames.js
@@ -51,8 +51,8 @@ exports.testHostnames = function (test) {
   ];
 
   hostnames.forEach(function(c) {
-    test.equal(supergenpass.isolateHostname(c[0], false), c[1]);
-    test.equal(supergenpass.isolateHostname(c[0], true), c[2]);
+    test.equal(supergenpass.hostname(c[0], { disableTLD: false }), c[1]);
+    test.equal(supergenpass.hostname(c[0], { disableTLD: true }), c[2]);
   });
 
   test.done();


### PR DESCRIPTION
I suggest renaming the method for aestetic reasons and simplicity.

I suggest the options object for the following reasons:
1. Flag parameters are suboptimal because they read poorly. In your own example you are forced to use a temporary variable to explain what is happening. In tests, however, you do not do that, and we have the popular result where there is a meaningless `false` or `true`, that is hard to understand.
2. `disableTLD` is an option. It is easy to imagine the `hostname` API getting more options in the future.
   In such a case having a mandatory second argument will be harmful.
3. There is a certain beauty in API matching the main API, isn't there?
