### PR TITLE
Rename disableTLD option to removeSubdomains

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ var supergenpass = require('supergenpass');
 // Generate a password from a master password and a URL or a domain.
 supergenpass('master-password', 'http://domain.example.com/', {
 
-    // Disable subdomain removal
-    disableTLD: false,
-
     // Length of the generated password
     length: 10,
 
     // md5 or sha512
     method: 'md5',
+
+    // Use subdomain removal
+    removeSubdomains: true,
 
     // Optional secret in addition to master password
     secret: ''
@@ -29,8 +29,8 @@ supergenpass('master-password', 'http://domain.example.com/', {
 
 // Isolate a hostname from a URL using SGP's rules.
 supergenpass.hostname('http://domain.example.com/', {
-    // Disable subdomain removal
-    disableTLD: false
+    // Use subdomain removal
+    removeSubdomains: true
 });
 ```
 

--- a/supergenpass.js
+++ b/supergenpass.js
@@ -119,10 +119,12 @@ var api = function (masterPassword, domain, options) {
 	options.secret = options.secret || options.salt || '';
 	options.length = gp2_validate_length(options.length);
 	options.method = options.method || 'md5';
-	options.disableTLD = options.disableTLD || false;
+	options.removeSubdomains = typeof options.removeSubdomains === 'undefined' ?
+		true :
+		!!options.removeSubdomains;
 
 	// Load input.
-	domain = gp2_process_uri(domain, options.disableTLD);
+	domain = gp2_process_uri(domain, !options.removeSubdomains);
 
 	// Generate password.
 	return gp2_generate_passwd(
@@ -137,9 +139,11 @@ api.hostname = function (url, options) {
 
 	// Load options.
 	options = options || {};
-	options.disableTLD = options.disableTLD || false;
+	options.removeSubdomains = typeof options.removeSubdomains === 'undefined' ?
+		true :
+		!!options.removeSubdomains;
 
-	return gp2_process_uri(url, options.disableTLD);
+	return gp2_process_uri(url, !options.removeSubdomains);
 
 };
 

--- a/tests/hostnames.js
+++ b/tests/hostnames.js
@@ -51,8 +51,8 @@ exports.testHostnames = function (test) {
   ];
 
   hostnames.forEach(function(c) {
-    test.equal(supergenpass.hostname(c[0], { disableTLD: false }), c[1]);
-    test.equal(supergenpass.hostname(c[0], { disableTLD: true }), c[2]);
+    test.equal(supergenpass.hostname(c[0], { removeSubdomains: true }), c[1]);
+    test.equal(supergenpass.hostname(c[0], { removeSubdomains: false }), c[2]);
   });
 
   test.done();

--- a/tests/simple.js
+++ b/tests/simple.js
@@ -6,7 +6,7 @@ exports.testSimple = function(test){
         ['sJfoZg3nU8', 'test', 'example.com', { method: 'sha512' }],
         ['aC81', 'test', 'example.com', { length: 4, method: 'sha512' }],
         ['zPQSNhTzs9fS', 'test', 'https://www.google.com/', { length: 12, salt: 'test' }],
-        ['q8ZWYccWDt', 'test', 'https://www.google.com/', { disableTLD: true, method: 'sha512' }],
+        ['q8ZWYccWDt', 'test', 'https://www.google.com/', { removeSubdomains: false, method: 'sha512' }],
         ['aRFG84Gim9', 'test', 'example.co.uk'],
         ['hSF8nTst4A', 'test', 'example.gov.ac']
     ];


### PR DESCRIPTION
In #9, @chriszarate has suggested that the option name `disableTLD` is imperfect.
I agree. We can still change the name, but what should it be?

After long consideration I came up with `removeSubdomains`.
I think a long time ago the bookmarklet had a similar wording as well.

This wording more clearly explains its behavior.
In addition, negative options lead to double negatives in setting the option,
which is significantly more confusing than positives.

What do you think?
