### PR TITLE
Strict errors on small and big lengths

### DIFF
--- a/supergenpass.js
+++ b/supergenpass.js
@@ -120,7 +120,7 @@ var api = function (masterPassword, domain, options) {
 	options.length = typeof options.length === 'undefined' ?
 		10 : Number(options.length);
 
-	if (isNaN(options.length) || options.length < 1) {
+	if (isNaN(options.length) || options.length < 4 || 24 < options.length) {
 		throw new Error('Invalid length passed');
 	}
 

--- a/tests/failures.js
+++ b/tests/failures.js
@@ -5,6 +5,8 @@ exports.testFailure = function(test){
         { method: 'unknown' },
         { length: -1 },
         { length: '123foo' },
+        { length: 3 },
+        { length: 28 },
     ];
 
     data.forEach(function(c){

--- a/tests/simple.js
+++ b/tests/simple.js
@@ -19,15 +19,3 @@ exports.testSimple = function(test){
 
     test.done();
 };
-
-exports.testLengthLimit = function(test){
-    test.equal(
-        supergenpass('test', 'example.com', { length: 1 }),
-        supergenpass('test', 'example.com', { length: 4 })
-    );
-    test.equal(
-        supergenpass('test', 'example.com', { length: 24 }),
-        supergenpass('test', 'example.com', { length: 28 })
-    );
-    test.done();
-};


### PR DESCRIPTION
This would mean more work on application level,
but I consider this an improvement.
After all, the users never know that their security is not at the level they expect it to.

It's also confusing that `supergenpass(..., ..., { length: a }) !== a`.
