### PR TITLE
Add passthrough feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ Alternatively, you can supply your own hash function. This hash function must
 accept a string value and return a string value. Returned hashes should be at
 least 24 characters and will be subject to SGP’s password validation rules.
 
+### passthrough
+
+* Default `false`
+* Expects `Boolean`
+
+A boolean value directing whether or not to use the url as is without
+validation or changes.
+
 ### removeSubdomains
 
 * Default `true`

--- a/src/lib/generate.js
+++ b/src/lib/generate.js
@@ -39,6 +39,7 @@ function generate(
     hashRounds: 10,
     length: 10,
     method: 'md5',
+    passthrough: false,
     removeSubdomains: true,
     secret: '',
   };
@@ -50,7 +51,7 @@ function generate(
   validatePasswordLength(masterPassword + options.secret);
   validateLength(options.length);
 
-  const domain = hostname(url, options);
+  const domain = options.passthrough ? url : hostname(url, options);
   const input = `${masterPassword}${options.secret}:${domain}`;
 
   hashRound(input, options.length, hash(options.method), options.hashRounds, callback);

--- a/tests/generate.js
+++ b/tests/generate.js
@@ -123,6 +123,14 @@ const testData = [
     'rnXePhv0JG',
     'จงฝ่าฟันพัฒนาวิชาการ',
   ],
+  [
+    'pgQuWBavN6',
+    'test',
+    'email@example.com',
+    {
+      passthrough: true,
+    },
+  ],
 ];
 
 testData.forEach((args) => {


### PR DESCRIPTION
to make supergenpass more versatile and also accept email addresses you can now directly passthrough the string you type in as url.